### PR TITLE
Allow nested Cmake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(lfc
   )
 
 target_include_directories(lfc
-	PUBLIC ${PROJECT_SOURCE_DIR}/include
+  PUBLIC ${PROJECT_SOURCE_DIR}/include
   )
 
 if(${BUILD_TESTING})


### PR DESCRIPTION
I wanted to give at building `longfi-device` with cmake. I ran into the issue when hitting your Cmake files, since my `CMAKE_SOURCE_DIR` is a level up.

This should allow nested building better.