### PR TITLE
Bump to cursor with bugfixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ include(FetchContent)
 FetchContent_Declare(
   cursor
   GIT_REPOSITORY https://github.com/JayKickliter/cursor.git
-  GIT_TAG        0.8.0
+  GIT_TAG        0.8.1
   )
 FetchContent_GetProperties(cursor)
 if(NOT cursor_POPULATED)


### PR DESCRIPTION
Upsteam cursor fixed some warnings that show up in ubsan due to impliciit integer conversion.