### PR TITLE
Use both clang and gcc on CI

### DIFF
--- a/ci/travis.yml
+++ b/ci/travis.yml
@@ -1,10 +1,11 @@
 language: c
 
+compiler:
+  - clang
+  - gcc
+
 addons:
   apt:
-    sources:
-      - llvm-toolchain-trusty-5.0
-      - key_url: 'http://apt.llvm.org/llvm-snapshot.gpg.key'
     packages:
       - clang-format-5.0
       - cppcheck


### PR DESCRIPTION
They sometimes have different warnings, so it's best to build with both.